### PR TITLE
feat(v0.2.1): add Simple Inventory Management as a notable BYO MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this list are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning follows [SemVer](https://semver.org/spec/v2.0.0.html). Pre-1.0.0, minor-level changes can include additions and structural moves; patch-level changes are corrections, polish, and lint fixes.
 
+## [0.2.1] - 2026-07-30
+
+### Added
+- **Bring Your Own MCP:** [Simple Inventory Management](https://simpleinventorymanagement.com) — public hosted MCP server (`simpleinventorymanagement.com/mcp`) for reading and updating live stock over OAuth. Listed under BYO MCP (not an in-app catalog tile); add via grok.com/connectors → New Connector → Custom.
+
+### Changed
+- BYO MCP section reframed from a single X-server prose note into an alphabetized list of notable public hosted MCP servers (Simple Inventory Management + X hosted MCP), with the same entry format as catalog connectors.
+- README header: v0.2.1, `Last updated` July 30, 2026. Catalog connector total unchanged (30).
+
 ## [0.2.0] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A directory of the connectors and skills in xAI's [Grok Connectors](https://grok.com/connectors) and Grok Skills — 30 connector integrations plus 5 built-in skills plus Bring Your Own MCP, organized by category with descriptions, use cases, and hosted-MCP server endpoints for catalog connectors.
 
-**Version:** v0.2.0 | **Last updated:** July 23, 2026 | **Total connectors:** 30 | **Built-in skills:** 5 | **Categories:** 10 | **BYO MCP:** supported
+**Version:** v0.2.1 | **Last updated:** July 30, 2026 | **Total connectors:** 30 | **Built-in skills:** 5 | **Categories:** 10 | **BYO MCP:** supported
 
 See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
@@ -124,9 +124,12 @@ Grok supports custom Model Context Protocol servers. Any MCP server reachable ov
 
 For setup, authentication patterns, and local-server tunneling guidance, see the Custom MCP connectors documentation linked from the launch post above.
 
-The highest-profile public server you can add this way: X's official hosted MCP server (launched June 30, 2026), exposing 200+ X API endpoints — posts, search, users, bookmarks, trends — documented at [docs.x.com/mcp](https://docs.x.com/mcp).
+Notable public hosted MCP servers you can add this way (not part of the in-app catalog; paste the URL under Custom):
 
-Looking for MCP servers to connect? See the awesome-mcp-servers list in the Related section below for a broad community-maintained directory that should work with Grok's BYO MCP surface.
+- [Simple Inventory Management](https://simpleinventorymanagement.com) - Cloud inventory for small businesses with a built-in OAuth MCP server (`simpleinventorymanagement.com/mcp`) for reading and updating live stock from chat. *Use case: Checking items below reorder point, recording receipts and count adjustments, drafting a reorder list without opening the app.*
+- [X hosted MCP](https://docs.x.com/mcp) - X's official hosted MCP server (launched June 30, 2026), exposing 200+ X API endpoints — posts, search, users, bookmarks, trends. *Use case: Searching posts and trends from chat, pulling user or bookmark context into a conversation.*
+
+Looking for more MCP servers to connect? See the awesome-mcp-servers list in the Related section below for a broad community-maintained directory that should work with Grok's BYO MCP surface.
 
 
 ## Skills


### PR DESCRIPTION
## What you're adding

Simple Inventory Management — a public hosted MCP server (`https://simpleinventorymanagement.com/mcp`) for small-business inventory, addable via Grok's Bring Your Own MCP (Custom connector) path.

## Entry format

```
- [Simple Inventory Management](https://simpleinventorymanagement.com) - Cloud inventory for small businesses with a built-in OAuth MCP server (`simpleinventorymanagement.com/mcp`) for reading and updating live stock from chat. *Use case: Checking items below reorder point, recording receipts and count adjustments, drafting a reorder list without opening the app.*
```

Placed under **Bring Your Own MCP** (not the in-app catalog), alphabetized with X hosted MCP. Catalog total stays 30.

## Checklist

- [x] Connector is publicly available to Grok via BYO MCP (hosted MCP + OAuth; Custom connector URL)
- [x] Entry is placed in the correct section, alphabetized
- [x] Description is one sentence, no marketing language, ends with a period
- [x] `*Use case:*` italics block is included with 2–3 concrete scenarios
- [x] Link uses HTTPS and points to the canonical product page
- [x] No duplicate entry exists in another category
- [ ] `awesome-lint` — local Windows path failed repo-URL detection; CI will verify

## Notes

Per CONTRIBUTING, personal/custom Installed BYO connectors are out of scope for the main catalog list. This is a **public product hosted MCP** (same class as the existing X hosted MCP note), so it is listed under Bring Your Own MCP rather than as a `C`/`X` catalog tile. The BYO section was reframed into a short alphabetized list of notable public servers for consistency.