### PR TITLE
Add RateZip rates server as a public BYO MCP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ For setup, authentication patterns, and local-server tunneling guidance, see the
 
 The highest-profile public server you can add this way: X's official hosted MCP server (launched June 30, 2026), exposing 200+ X API endpoints — posts, search, users, bookmarks, trends — documented at [docs.x.com/mcp](https://docs.x.com/mcp).
 
+Another public, no-auth example: [RateZip Bank Deposit and Mortgage Rates](https://www.ratezip.com/methodology) (`https://mcp.ratezip.com/mcp`, streamable HTTP) - live US savings, CD, mortgage, and HELOC rates, each figure carrying its source and observation timestamp; also published in the official MCP Registry as `com.ratezip/rates`. *Use case: asking Grok for current top savings APYs or mortgage and HELOC rates with sources, without leaving chat.*
+
 Looking for MCP servers to connect? See the awesome-mcp-servers list in the Related section below for a broad community-maintained directory that should work with Grok's BYO MCP surface.
 
 


### PR DESCRIPTION
Adds a second public-server example to the **Bring Your Own MCP** section (alongside X's hosted server): **RateZip Bank Deposit and Mortgage Rates** — `https://mcp.ratezip.com/mcp` (streamable HTTP, no auth).

- Live US savings, CD, mortgage, and HELOC rates; every figure carries its source URL and observation timestamp
- Published in the official MCP Registry as `com.ratezip/rates`
- Verified working in Grok via New Connector → Custom on 2026-08-10 (tools auto-discovered, 'Connector added successfully')

Disclosure: I operate this server (Peklava LLC / RateZip). It's free, public, read-only rate data — no offers or ads in the feed. Happy to adjust wording or placement if you'd rather scope the section differently.