### PR TITLE
Add AdsAgent Meta MCP (Custom MCP) under Advertising

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This list is maintained weekly. To contribute, see [CONTRIBUTING.md](CONTRIBUTIN
 
 ## Advertising
 
+- [AdsAgent Meta MCP](https://adsagent.md/docs/mcp-onboarding) **`C`** - Hosted Meta advertising MCP at `https://adsagent.md/mcp/v2`: bounded insights reads, templates, async tasks, and confirmation-gated campaign writes. OAuth 2.0 with dynamic client registration (RFC 7591); streamable HTTP MCP. *Use case: Checking product or campaign performance from chat, preparing Meta ad operations with explicit human approval before any write.*
 - [X Ads](https://ads.x.com) **`C`** - Give Grok access to your X ad campaigns: view campaigns, ad groups, and ads - and update creatives or create new ads with Imagine. xAI states it does not train on X Ads data and that Grok only reads or changes ads when you ask. *Use case: Checking campaign performance from chat, adjusting a running ad group, generating fresh creatives without opening Ads Manager.*
 
 


### PR DESCRIPTION
## Summary

Adds **AdsAgent Meta MCP** as a documented **Custom MCP (`C`)** connector for Meta (Facebook/Instagram) advertising operations via Grok's **New Connector → Custom** flow.

Users enter MCP URL: `https://adsagent.md/mcp/v2`

Official onboarding: https://adsagent.md/docs/mcp-onboarding

## Change

Insert under `## Advertising`, alphabetically before `X Ads`.

## Verification

- Custom MCP path documented at https://docs.x.ai/grok/connectors
- OAuth metadata: https://adsagent.md/.well-known/oauth-authorization-server
- MCP profile: https://adsagent.md/mcp/v2 (401 without bearer; OAuth after connect)
- MCP Registry: `md.adsagent/meta-mcp` (active 2026-08-18)
  - Search: https://registry.modelcontextprotocol.io/v0.1/servers?search=md.adsagent%2Fmeta-mcp
  - Latest: https://registry.modelcontextprotocol.io/v0.1/servers/md.adsagent%2Fmeta-mcp/versions/latest
  - Note: `https://registry.modelcontextprotocol.io/servers/...` is not a supported browse URL (404; use API links above)