### PR TITLE
Add Ryze AI (Google Ads, Meta Ads, GA4, Search Console MCP) to Advertising

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This list is maintained weekly. To contribute, see [CONTRIBUTING.md](CONTRIBUTIN
 
 - [X Ads](https://ads.x.com) **`C`** - Give Grok access to your X ad campaigns: view campaigns, ad groups, and ads - and update creatives or create new ads with Imagine. xAI states it does not train on X Ads data and that Grok only reads or changes ads when you ask. *Use case: Checking campaign performance from chat, adjusting a running ad group, generating fresh creatives without opening Ads Manager.*
 
+- [Ryze AI](https://www.get-ryze.ai) **`M`** - Bring-your-own MCP for Google Ads, Meta Ads, GA4 and Search Console (`https://connector.get-ryze.ai/mcp`, OAuth, free). Audit wasted spend, explain CPA changes, pull any report, and apply budget or negative-keyword changes with approval. *Use case: "Which search terms spent over $50 with zero conversions this month?"*
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ This list is maintained weekly. To contribute, see [CONTRIBUTING.md](CONTRIBUTIN
 
 - [X Ads](https://ads.x.com) **`C`** - Give Grok access to your X ad campaigns: view campaigns, ad groups, and ads - and update creatives or create new ads with Imagine. xAI states it does not train on X Ads data and that Grok only reads or changes ads when you ask. *Use case: Checking campaign performance from chat, adjusting a running ad group, generating fresh creatives without opening Ads Manager.*
 
-- [Google Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/google-ads-mcp) **`M`** - Bring-your-own MCP for Google Ads (`https://connector.get-ryze.ai/mcp`, OAuth, free): search terms, GAQL reports, Keyword Planner, recommendations, approved budget and negative-keyword changes. *Use case: "Which search terms spent over $50 with zero conversions this month?"*
-- [Meta Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/meta-ads-mcp) **`M`** - Bring-your-own MCP for Facebook and Instagram Ads (same endpoint): Insights by ad set and ad, creative fatigue, lead forms, Ad Library research, approved edits. *Use case: "Which ads have frequency above 3 and falling CTR this week?"*
+- [Google Ads MCP by Ryze AI](https://www.get-ryze.ai/google-ads-mcp) **`M`** - Bring-your-own MCP for Google Ads (`https://connector.get-ryze.ai/mcp`, OAuth, free): search terms, GAQL reports, Keyword Planner, recommendations, approved budget and negative-keyword changes. *Use case: "Which search terms spent over $50 with zero conversions this month?"*
+- [Meta Ads MCP by Ryze AI](https://www.get-ryze.ai/meta-ads-mcp) **`M`** - Bring-your-own MCP for Facebook and Instagram Ads (same endpoint): Insights by ad set and ad, creative fatigue, lead forms, Ad Library research, approved edits. *Use case: "Which ads have frequency above 3 and falling CTR this week?"*
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ This list is maintained weekly. To contribute, see [CONTRIBUTING.md](CONTRIBUTIN
 
 - [X Ads](https://ads.x.com) **`C`** - Give Grok access to your X ad campaigns: view campaigns, ad groups, and ads - and update creatives or create new ads with Imagine. xAI states it does not train on X Ads data and that Grok only reads or changes ads when you ask. *Use case: Checking campaign performance from chat, adjusting a running ad group, generating fresh creatives without opening Ads Manager.*
 
-- [Ryze AI](https://www.get-ryze.ai) **`M`** - Bring-your-own MCP for Google Ads, Meta Ads, GA4 and Search Console (`https://connector.get-ryze.ai/mcp`, OAuth, free). Audit wasted spend, explain CPA changes, pull any report, and apply budget or negative-keyword changes with approval. *Use case: "Which search terms spent over $50 with zero conversions this month?"*
+- [Google Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/google-ads-mcp) **`M`** - Bring-your-own MCP for Google Ads (`https://connector.get-ryze.ai/mcp`, OAuth, free): search terms, GAQL reports, Keyword Planner, recommendations, approved budget and negative-keyword changes. *Use case: "Which search terms spent over $50 with zero conversions this month?"*
+- [Meta Ads MCP by Ryze AI](https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp/tree/main/meta-ads-mcp) **`M`** - Bring-your-own MCP for Facebook and Instagram Ads (same endpoint): Insights by ad set and ad, creative fatigue, lead forms, Ad Library research, approved edits. *Use case: "Which ads have frequency above 3 and falling CTR this week?"*
 
 ## Analytics
 


### PR DESCRIPTION
Adds Ryze AI under Advertising as a bring-your-own MCP connector.

Hosted MCP at `https://connector.get-ryze.ai/mcp` (OAuth, free). Grok gets read access to the user's Google Ads, Meta Ads, GA4 and Search Console, plus write actions (budget, pause, negative keywords) that ask for approval. Add via grok.com/connectors → New Connector → Custom, or through a Grok Bot.

Repo: https://github.com/irinabuht12-oss/google-meta-ads-ga4-mcp (official MCP registry: io.github.irinabuht12-oss/google-meta-ads-ga4-mcp). Setup: https://www.get-ryze.ai/how-to-connect-claude-to-google-meta-ads-mcp